### PR TITLE
Create with url

### DIFF
--- a/httpd/handlers/createPost.go
+++ b/httpd/handlers/createPost.go
@@ -1,50 +1,50 @@
 package handlers
 
 import (
-  "encoding/json"
-  "net/http"
+	"encoding/json"
+	"net/http"
 
-  "github.com/jjcm/soci-backend/models"
+	"github.com/jjcm/soci-backend/models"
 )
 
 // PostCreationRequest this is the shape of the JSON request that is needed to
 // create a new post
 type PostCreationRequest struct {
-  Title   string `json:"title"`
-  URL     string `json:"url"`
-  Content string `json:"content"`
-  Type    string `json:"type"`
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Content string `json:"content"`
+	Type    string `json:"type"`
 }
 
 // CreatePost - protected http handler
 // the user associated with the passed auth token can create a new post
 func CreatePost(w http.ResponseWriter, r *http.Request) {
-  // any non GET handlers need to attach CORS headers. I always forget about that
-  CorsAdjustments(&w)
+	// any non GET handlers need to attach CORS headers. I always forget about that
+	CorsAdjustments(&w)
 
-  // silly AJAX prflight, here's where we can put in the CORS requirements
-  if r.Method == "OPTIONS" {
-    SendResponse(w, "", 200)
-    return
-  }
+	// silly AJAX prflight, here's where we can put in the CORS requirements
+	if r.Method == "OPTIONS" {
+		SendResponse(w, "", 200)
+		return
+	}
 
-  if r.Method != "POST" {
-    SendResponse(w, MakeError("You can only POST to the post creation route"), 405)
-    return
-  }
+	if r.Method != "POST" {
+		SendResponse(w, MakeError("You can only POST to the post creation route"), 405)
+		return
+	}
 
-  u := models.User{}
-  u.FindByID(r.Context().Value("user_id").(int))
+	u := models.User{}
+	u.FindByID(r.Context().Value("user_id").(int))
 
-  var postRequest PostCreationRequest
+	var postRequest PostCreationRequest
 
-  decoder := json.NewDecoder(r.Body)
-  decoder.Decode(&postRequest)
-  newPost, err := u.CreatePost(postRequest.Title, postRequest.URL, postRequest.Content, postRequest.Type)
-  if err != nil {
-    sendSystemError(w, err)
-    return
-  }
+	decoder := json.NewDecoder(r.Body)
+	decoder.Decode(&postRequest)
+	newPost, err := u.CreatePost(postRequest.Title, postRequest.URL, postRequest.Content, postRequest.Type)
+	if err != nil {
+		sendSystemError(w, err)
+		return
+	}
 
-  SendResponse(w, &newPost, 200)
+	SendResponse(w, &newPost, 200)
 }

--- a/httpd/handlers/createPost.go
+++ b/httpd/handlers/createPost.go
@@ -11,6 +11,7 @@ import (
 // create a new post
 type PostCreationRequest struct {
 	Title   string `json:"title"`
+	URL			string `json:"url"`
 	Content string `json:"content"`
 	Type    string `json:"type"`
 }
@@ -39,7 +40,7 @@ func CreatePost(w http.ResponseWriter, r *http.Request) {
 
 	decoder := json.NewDecoder(r.Body)
 	decoder.Decode(&postRequest)
-	newPost, err := u.CreatePost(postRequest.Title, postRequest.Content, postRequest.Type)
+	newPost, err := u.CreatePost(postRequest.Title, postRequest.URL, postRequest.Content, postRequest.Type)
 	if err != nil {
 		sendSystemError(w, err)
 		return

--- a/httpd/handlers/createPost.go
+++ b/httpd/handlers/createPost.go
@@ -1,50 +1,50 @@
 package handlers
 
 import (
-	"encoding/json"
-	"net/http"
+  "encoding/json"
+  "net/http"
 
-	"github.com/jjcm/soci-backend/models"
+  "github.com/jjcm/soci-backend/models"
 )
 
 // PostCreationRequest this is the shape of the JSON request that is needed to
 // create a new post
 type PostCreationRequest struct {
-	Title   string `json:"title"`
-	URL			string `json:"url"`
-	Content string `json:"content"`
-	Type    string `json:"type"`
+  Title   string `json:"title"`
+  URL     string `json:"url"`
+  Content string `json:"content"`
+  Type    string `json:"type"`
 }
 
 // CreatePost - protected http handler
 // the user associated with the passed auth token can create a new post
 func CreatePost(w http.ResponseWriter, r *http.Request) {
-	// any non GET handlers need to attach CORS headers. I always forget about that
-	CorsAdjustments(&w)
+  // any non GET handlers need to attach CORS headers. I always forget about that
+  CorsAdjustments(&w)
 
-	// silly AJAX prflight, here's where we can put in the CORS requirements
-	if r.Method == "OPTIONS" {
-		SendResponse(w, "", 200)
-		return
-	}
+  // silly AJAX prflight, here's where we can put in the CORS requirements
+  if r.Method == "OPTIONS" {
+    SendResponse(w, "", 200)
+    return
+  }
 
-	if r.Method != "POST" {
-		SendResponse(w, MakeError("You can only POST to the post creation route"), 405)
-		return
-	}
+  if r.Method != "POST" {
+    SendResponse(w, MakeError("You can only POST to the post creation route"), 405)
+    return
+  }
 
-	u := models.User{}
-	u.FindByID(r.Context().Value("user_id").(int))
+  u := models.User{}
+  u.FindByID(r.Context().Value("user_id").(int))
 
-	var postRequest PostCreationRequest
+  var postRequest PostCreationRequest
 
-	decoder := json.NewDecoder(r.Body)
-	decoder.Decode(&postRequest)
-	newPost, err := u.CreatePost(postRequest.Title, postRequest.URL, postRequest.Content, postRequest.Type)
-	if err != nil {
-		sendSystemError(w, err)
-		return
-	}
+  decoder := json.NewDecoder(r.Body)
+  decoder.Decode(&postRequest)
+  newPost, err := u.CreatePost(postRequest.Title, postRequest.URL, postRequest.Content, postRequest.Type)
+  if err != nil {
+    sendSystemError(w, err)
+    return
+  }
 
-	SendResponse(w, &newPost, 200)
+  SendResponse(w, &newPost, 200)
 }

--- a/models/post_test.go
+++ b/models/post_test.go
@@ -12,7 +12,7 @@ func TestWeCanCreateAPost(t *testing.T) {
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	p, err := author.CreatePost("Post Title", "lorem ipsum", "image")
+	p, err := author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 	if err != nil {
 		t.Errorf("Post creation should have worked. Error recieved: %v", err)
 	}
@@ -32,7 +32,7 @@ func TestWeCanFindAPostByItsURL(t *testing.T) {
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	author.CreatePost("Post Title", "lorem ipsum", "image")
+	author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 
 	p := Post{}
 	p.FindByURL("post-title")
@@ -50,7 +50,7 @@ func TestWeCanFindAPostByItsID(t *testing.T) {
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	author.CreatePost("Post Title", "lorem ipsum", "image")
+	author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 
 	p := Post{}
 	p.FindByID(1)
@@ -69,7 +69,7 @@ func TestWhenWeMarshalAPostToJSONItHasTheShapeThatWeExpect(t *testing.T) {
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	p, err := author.CreatePost("Post Title", "lorem ipsum", "image")
+	p, err := author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 	if err != nil {
 		t.Errorf("We should be able to create a post. Error: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestWeTagAPost(t *testing.T) {
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	author.CreatePost("Post Title", "lorem ipsum", "image")
+	author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 
 	p := Post{}
 	p.FindByURL("post-title")
@@ -115,7 +115,7 @@ func TestWeCantTagAPostWithTheSameTagMoreThanOneTime(t *testing.T) {
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	author.CreatePost("Post Title", "lorem ipsum", "image")
+	author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 
 	p := Post{}
 	p.FindByURL("post-title")
@@ -149,7 +149,7 @@ func TestIfWeCreateAPostWithTheSameURLTheSystemWillGenerateAUniqueOne(t *testing
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	p1, err := author.CreatePost("Post Title", "lorem ipsum", "image")
+	p1, err := author.CreatePost("Post Title", "post-title", "lorem ipsum", "image")
 	if err != nil {
 		t.Errorf("Post creation should have worked. Error recieved: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestIfWeCreateAPostWithTheSameURLTheSystemWillGenerateAUniqueOne(t *testing
 	}
 
 	// now let's create a second post with the same title
-	p2, err := author.CreatePost("Post Title", "Dolor sit amit", "image")
+	p2, err := author.CreatePost("Post Title", "post-title", "Dolor sit amit", "image")
 	if err != nil {
 		t.Errorf("Post creation should have worked. Error recieved: %v", err)
 	}
@@ -167,46 +167,12 @@ func TestIfWeCreateAPostWithTheSameURLTheSystemWillGenerateAUniqueOne(t *testing
 	}
 
 	// now let's create a third post with the same title
-	p3, err := author.CreatePost("Post Title", "Dolor sit amit", "image")
+	p3, err := author.CreatePost("Post Title", "post-title", "Dolor sit amit", "image")
 	if err != nil {
 		t.Errorf("Post creation should have worked. Error recieved: %v", err)
 	}
 	if p3.URL != "post-title-3" {
 		t.Errorf("The URL for the third post should be different from the original created post. Post3 url: %v", p2.URL)
-	}
-}
-
-func TestOurUrlGeneratorCorrectlyTruncatesToASafeDatabaseLength(t *testing.T) {
-	title := "This is a really long post title that will be truncated into a url that has the correct length for the database, and although this is a really silly example it still needs a test so the database doesn't blow up when some random human does something like this just to push the system to its limits"
-	if createURLFromTitle(title) != "this-is-a-really-long-post-title-that-will-be-truncated-into-a-url-that-has-the-correct-length-for-the-database-and-although-this-is-a-really-silly-example-it-still-needs-a-test-so-the-database-doesnt-blow-up-when-some-random-human-does-something-like-th" {
-		t.Errorf("Expected title wasn't generated")
-	}
-}
-
-func TestIfWeCreateAPostWithAReallyLongTitleTheTitleAndUrlAreTruncatedCorrectly(t *testing.T) {
-	setupTestingDB()
-	defer teardownTestingDB()
-
-	// create an author for post
-	CreateUser("example@example.com", "password")
-	author := User{}
-	author.FindByEmail("example@example.com")
-	p1, err := author.CreatePost("This is a really long post title that will be truncated into a url that has the correct length for the database, and although this is a really silly example it still needs a test so the database doesn't blow up when some random human does something like this just to push the system to its limits", "lorem ipsum", "image")
-	if err != nil {
-		t.Errorf("Post creation should have worked. Error recieved: %v", err)
-	}
-	if p1.URL != "this-is-a-really-long-post-title-that-will-be-truncated-into-a-url-that-has-the-correct-length-for-the-database-and-although-this-is-a-really-silly-example-it-still-needs-a-test-so-the-database-doesnt-blow-up-when-some-random-human-does-something-like-th" {
-		t.Errorf("The post that is returned should be the newly created post")
-	}
-
-	// do it again for url suffix generation checking
-
-	p2, err := author.CreatePost("This is a really long post title that will be truncated into a url that has the correct length for the database, and although this is a really silly example it still needs a test so the database doesn't blow up when some random human does something like this just to push the system to its limits", "lorem ipsum", "image")
-	if err != nil {
-		t.Errorf("Post creation should have worked. Error recieved: %v", err)
-	}
-	if p2.URL != "this-is-a-really-long-post-title-that-will-be-truncated-into-a-url-that-has-the-correct-length-for-the-database-and-although-this-is-a-really-silly-example-it-still-needs-a-test-so-the-database-doesnt-blow-up-when-some-random-human-does-something-like--2" {
-		t.Errorf("The post that is returned should be the newly created post")
 	}
 }
 
@@ -218,7 +184,7 @@ func TestIfAPostIsCreatedWithAnEmptyTypeItGetsSetToTheDefaultTypeImage(t *testin
 	CreateUser("example@example.com", "password")
 	author := User{}
 	author.FindByEmail("example@example.com")
-	p, err := author.CreatePost("Title", "lorem ipsum", "") // note the empty 3rd param
+	p, err := author.CreatePost("Title", "post-title", "lorem ipsum", "") // note the empty 3rd param
 	if err != nil {
 		t.Errorf("Post creation should have worked. Error recieved: %v", err)
 	}

--- a/models/user.go
+++ b/models/user.go
@@ -48,11 +48,12 @@ func (u *User) FindByID(id int) error {
 
 // CreatePost - create a new post in the database and set the current User as
 // the author
-func (u *User) CreatePost(title, content, postType string) (Post, error) {
+func (u *User) CreatePost(title, url, content, postType string) (Post, error) {
 	p := Post{}
 	now := time.Now().Format("2006-01-02 15:04:05")
 
-	postURL := createURLFromTitle(title)
+	postURL := url
+	// TODO: this needs some backend verification that it's only /^[0-9A-Za-z-_]+$/
 
 	// perpare and truncate the title if necessary
 	postTitle := title

--- a/models/utilities.go
+++ b/models/utilities.go
@@ -4,14 +4,6 @@ import (
 	"strings"
 )
 
-func createURLFromTitle(title string) string {
-	convertedString := strings.ToLower(strings.Join(splitByWords(title), "-"))
-	if len(convertedString) > 255 {
-		convertedString = convertedString[0:254]
-	}
-	return convertedString
-}
-
 func splitByWords(s string) []string {
 	trimmedString := strings.TrimSpace(removeReservedChars(s))
 	parts := strings.Split(trimmedString, " ")


### PR DESCRIPTION
I needed the ability to create post with a url predefined.

I.e., here's the submission form (Ignore the fact that I forgot a title field):
![image](https://user-images.githubusercontent.com/50971/70139793-5b1b6580-16e7-11ea-8874-1c458f0c2c05.png)

This should do it, but I honestly just yolo'd this as there's a few things that need to be updated before this is fully merged: 

1.) Review that those tests that I deleted are indeed no longer being used. I think we can safely get rid of createUrlFromTitle. 
2.) Either remove the single test from utilities_test.go, or remove the file. I wasn't sure if we should keep the file if the only test in it is testing the url creation from a title, so I left it untouched. 
3.) Add a verification that the URL is only alphanumerics, hyphens, and underscores. 
4.) If the url is longer than 255 characters (I think that's what you were testing before), then reject the request with a 500.